### PR TITLE
Add styled front-end template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Rename this file to .env and fill in your credentials
+EMAIL_USER=seu_usuario@gmail.com
+EMAIL_PASS=sua_senha
+# Opcional: destinatário padrão
+DEFAULT_RECIPIENT=rba1807@gmail.com
+# Servidor SMTP e porta (padrao Gmail)
+SMTP_SERVER=smtp.gmail.com
+SMTP_PORT=465

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Gerador de Contratos
+
+Aplicação simples em Flask para gerar contratos a partir de um modelo `.docx` e enviar por e-mail.
+
+## Requisitos
+
+- Python 3.10+
+- Pacotes listados em `requirements.txt`
+
+## Configuração
+
+1. Instale as dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copie `.env.example` para `.env` e preencha `EMAIL_USER` e `EMAIL_PASS` com os dados de sua conta de e-mail. Opcionalmente ajuste `DEFAULT_RECIPIENT`, `SMTP_SERVER` e `SMTP_PORT`. O arquivo `.env` é carregado automaticamente pela aplicação.
+
+## Uso
+
+Execute a aplicação com:
+
+```bash
+python3 app.py
+```
+
+Acesse `http://localhost:5000` em seu navegador, preencha o formulário e envie. O contrato será preenchido com os dados informados e enviado para o e-mail configurado.
+
+O arquivo `Contrato Vitorino.docx` é o modelo utilizado e **não deve ser alterado**.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,84 @@
+# Simple web app to generate and send contract via email
+import os
+from flask import Flask, render_template, request
+from docxtpl import DocxTemplate
+import smtplib
+from email.message import EmailMessage
+from io import BytesIO
+from pathlib import Path
+
+
+def load_env() -> None:
+    """Load variables from a .env file if it exists."""
+    env_path = Path(__file__).with_name('.env')
+    if env_path.exists():
+        with env_path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, val = line.split('=', 1)
+                os.environ.setdefault(key.strip(), val.strip())
+
+
+load_env()
+
+app = Flask(__name__)
+
+
+TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), 'Contrato Vitorino.docx')
+RECIPIENT = os.environ.get('DEFAULT_RECIPIENT', 'rba1807@gmail.com')
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    status = ''
+    if request.method == 'POST':
+        data = {k: request.form.get(k) for k in request.form.keys()}
+        try:
+            doc = DocxTemplate(TEMPLATE_PATH)
+            doc.render({
+                'Comprador': data.get('Comprador'),
+                'CPF': data.get('CPF'),
+                'RG': data.get('RG'),
+                'Emissor': data.get('Emissor'),
+                'EstadoCivil': data.get('EstadoCivil'),
+                'Profissao': data.get('Profissao'),
+                'Endereço': data.get('Endereco'),
+                'Numero': data.get('Numero'),
+                'Complemento': data.get('Complemento'),
+                'Bairro': data.get('Bairro'),
+                'Cidade': data.get('Cidade'),
+                'CEP': data.get('CEP'),
+                'Quadra': data.get('Quadra'),
+                'Lote': data.get('Lote'),
+                'Testemunha': data.get('Testemunha'),
+                'CPF Test': data.get('CPFTest'),
+                'Testemunha2': data.get('Testemunha2'),
+                'CPF Test2': data.get('CPFTest2'),
+            })
+            buf = BytesIO()
+            doc.save(buf)
+            buf.seek(0)
+            send_email(buf.getvalue(), data.get('Comprador'))
+            status = 'Contrato enviado com sucesso.'
+        except Exception as e:
+            status = f'Falha ao enviar: {e}'
+    return render_template("form.html", status=status)
+
+def send_email(content: bytes, comprador: str):
+    user = os.environ['EMAIL_USER']
+    password = os.environ['EMAIL_PASS']
+    msg = EmailMessage()
+    msg['Subject'] = 'Contrato Gerado'
+    msg['From'] = user
+    msg['To'] = RECIPIENT
+    msg.set_content(f'Contrato gerado para {comprador}.')
+    msg.add_attachment(content, maintype='application', subtype='vnd.openxmlformats-officedocument.wordprocessingml.document', filename='Contrato.docx')
+    host = os.environ.get('SMTP_SERVER', 'smtp.gmail.com')
+    port = int(os.environ.get('SMTP_PORT', '465'))
+    with smtplib.SMTP_SSL(host, port) as smtp:
+        smtp.login(user, password)
+        smtp.send_message(msg)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+docxtpl

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Gerador de Contratos</title>
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 700px;
+            margin: 40px auto;
+            background: #fff;
+            padding: 20px 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        form {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        label {
+            display: flex;
+            flex-direction: column;
+            font-weight: bold;
+            font-size: 0.9rem;
+        }
+        input[type="text"] {
+            padding: 8px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-size: 1rem;
+        }
+        button {
+            margin-top: 16px;
+            padding: 10px;
+            font-size: 1rem;
+            border: none;
+            border-radius: 4px;
+            background-color: #3498db;
+            color: #fff;
+            cursor: pointer;
+            width: 50%;
+            align-self: center;
+        }
+        button:hover {
+            background-color: #2980b9;
+        }
+        .status {
+            text-align: center;
+            padding: 10px;
+            border-radius: 4px;
+            margin-bottom: 20px;
+            color: #fff;
+            background-color: #2ecc71;
+        }
+        @media (max-width: 600px) {
+            .container {
+                margin: 20px;
+                padding: 15px;
+            }
+            button {
+                width: 100%;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Gerador de Contratos</h1>
+        {% if status %}<p class="status">{{ status }}</p>{% endif %}
+        <form method="post">
+            <label>Nome completo
+                <input type="text" name="Comprador" required>
+            </label>
+            <label>CPF
+                <input type="text" name="CPF" required>
+            </label>
+            <label>RG
+                <input type="text" name="RG" required>
+            </label>
+            <label>Órgão emissor
+                <input type="text" name="Emissor" required>
+            </label>
+            <label>Estado civil
+                <input type="text" name="EstadoCivil" required>
+            </label>
+            <label>Profissão
+                <input type="text" name="Profissao" required>
+            </label>
+            <label>Endereço
+                <input type="text" name="Endereco" required>
+            </label>
+            <label>Número
+                <input type="text" name="Numero" required>
+            </label>
+            <label>Complemento
+                <input type="text" name="Complemento" required>
+            </label>
+            <label>Bairro
+                <input type="text" name="Bairro" required>
+            </label>
+            <label>Cidade
+                <input type="text" name="Cidade" required>
+            </label>
+            <label>CEP
+                <input type="text" name="CEP" required>
+            </label>
+            <label>Quadra
+                <input type="text" name="Quadra" required>
+            </label>
+            <label>Lote
+                <input type="text" name="Lote" required>
+            </label>
+            <label>Testemunha 1
+                <input type="text" name="Testemunha" required>
+            </label>
+            <label>CPF Testemunha 1
+                <input type="text" name="CPFTest" required>
+            </label>
+            <label>Testemunha 2
+                <input type="text" name="Testemunha2" required>
+            </label>
+            <label>CPF Testemunha 2
+                <input type="text" name="CPFTest2" required>
+            </label>
+            <button type="submit">Gerar Contrato</button>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create modern HTML template with CSS styling
- switch Flask view to render_template using the new template

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6845d3d7af04832188e214db096d0163